### PR TITLE
NSInvocation Fix

### DIFF
--- a/RZDataBinding/NSObject+RZDataBinding.m
+++ b/RZDataBinding/NSObject+RZDataBinding.m
@@ -343,11 +343,11 @@ static void* const kRZDBKVOContext = (void *)&kRZDBKVOContext;
         if ( self.invocation.methodSignature.numberOfArguments > 2 ) {
             NSDictionary *changeDict = [self changeDictForKVOChange:change];
 
-            [self.invocation setArgument:&changeDict atIndex:2];
-            [self.invocation invoke];
+            // NSInvocation is unsafe for sending object arguments. Use objc_msgSend instead.
+            ((void(*)(id, SEL, NSDictionary *))objc_msgSend)(self.invocation.target, self.invocation.selector, changeDict);
         }
         else {
-            [self.invocation invoke];
+            ((void(*)(id, SEL))objc_msgSend)(self.invocation.target, self.invocation.selector);
         }
     }
 }

--- a/RZDataBinding/NSObject+RZDataBinding.m
+++ b/RZDataBinding/NSObject+RZDataBinding.m
@@ -347,7 +347,7 @@ static void* const kRZDBKVOContext = (void *)&kRZDBKVOContext;
             ((void(*)(id, SEL, NSDictionary *))objc_msgSend)(self.invocation.target, self.invocation.selector, changeDict);
         }
         else {
-            ((void(*)(id, SEL))objc_msgSend)(self.invocation.target, self.invocation.selector);
+            [self.invocation invoke];
         }
     }
 }


### PR DESCRIPTION
It turns out NSInvocation is generally unsafe for sending messages with object arguments, and should almost never be used for such. PR #8 switched over to using NSInvocation instead of storing target/action pairs separately. Now, NSInvocation will still store the target, action, and method signature, but will no longer be invoked to send the message.