### PR TITLE
Feature/jvisenti/primitive nil binding

### DIFF
--- a/RZDataBinding/NSObject+RZDataBinding.m
+++ b/RZDataBinding/NSObject+RZDataBinding.m
@@ -191,7 +191,7 @@ static void* const kRZDBKVOContext = (void *)&kRZDBKVOContext;
 
     if ( cachedValues == nil ) {
         cachedValues = [NSMutableDictionary dictionary];
-        objc_setAssociatedObject(self, _cmd, cachedValues, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        objc_setAssociatedObject(self, _cmd, cachedValues, OBJC_ASSOCIATION_RETAIN);
     }
 
     id primitive = cachedValues[propertyName];

--- a/RZDataBinding/NSObject+RZDataBinding.m
+++ b/RZDataBinding/NSObject+RZDataBinding.m
@@ -187,7 +187,14 @@ static void* const kRZDBKVOContext = (void *)&kRZDBKVOContext;
 
 + (BOOL)rz_isPrimitiveProperty:(NSString *)propertyName
 {
-    id primitive = objc_getAssociatedObject(self, _cmd);
+    NSMutableDictionary *cachedValues = objc_getAssociatedObject(self, _cmd);
+
+    if ( cachedValues == nil ) {
+        cachedValues = [NSMutableDictionary dictionary];
+        objc_setAssociatedObject(self, _cmd, cachedValues, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+
+    id primitive = cachedValues[propertyName];
 
     if ( primitive == nil ) {
         objc_property_t property = NULL;
@@ -231,7 +238,7 @@ static void* const kRZDBKVOContext = (void *)&kRZDBKVOContext;
         }
 
         primitive = @(propertyIsPrimitive);
-        objc_setAssociatedObject(self, _cmd, primitive, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        cachedValues[propertyName] = primitive;
     }
 
     return [primitive boolValue];

--- a/Tests/RZDBTests/RZDBTests.m
+++ b/Tests/RZDBTests/RZDBTests.m
@@ -237,7 +237,7 @@
     XCTAssertTrue([observer.string isEqualToString:@"test2"], @"String shouldn't change after keys are unbound");
 }
 
-- (void)testBindingEqualityCheck
+- (void)testKeyBindingEqualityCheck
 {
     RZDBTestObject *testObj = [RZDBTestObject new];
     RZDBTestObject *observer = [RZDBTestObject new];
@@ -273,7 +273,20 @@
     XCTAssertTrue(observer.callbackCalls == 105, @"Value shouldn't change after keys are unbound.");
 }
 
-- (void)testBindingChains
+- (void)testKeyBindingPrimitiveWithNilValue
+{
+    RZDBTestObject *testObj = [RZDBTestObject new];
+    RZDBTestObject *observer = [RZDBTestObject new];
+
+    testObj.string = nil;
+    observer.callbackCalls = 1;
+
+    [observer rz_bindKey:RZDB_KP_OBJ(observer, callbackCalls) toKeyPath:RZDB_KP_OBJ(testObj, string.length) ofObject:testObj];
+
+    XCTAssertTrue(observer.callbackCalls == 0, @"Nil value should translate to 0 when bound to a primitive.");
+}
+
+- (void)testKeyBindingChains
 {
     RZDBTestObject *obj1 = [RZDBTestObject new];
     RZDBTestObject *obj2 = [RZDBTestObject new];


### PR DESCRIPTION
#20 

Binding a primitive-type key to a key path that may contain an object value is unsafe due to the possibility that the object is `nil`. Attempting to set `nil` for a primitive-type key causes a crash. RZDB will now auto convert `nil` -> `0` for primitive-type properties.

**Note:** This automatic conversion will not work when binding to keys that aren't properties, but this is generally not done anyway.