### PR TITLE
Remove RZDBObservableObject

### DIFF
--- a/RZDataBinding/NSObject+RZDataBinding.m
+++ b/RZDataBinding/NSObject+RZDataBinding.m
@@ -65,7 +65,6 @@ static void* const kRZDBKVOContext = (void *)&kRZDBKVOContext;
 - (void)rz_removeTarget:(id)target action:(SEL)action boundKey:(NSString *)boundKey forKeyPath:(NSString *)keyPath;
 - (void)rz_observeBoundKeyChange:(NSDictionary *)change;
 - (void)rz_setBoundKey:(NSString *)key withValue:(id)value transform:(RZDBKeyBindingTransform)transform;
-- (void)rz_cleanupObservers;
 
 @end
 
@@ -165,17 +164,6 @@ static void* const kRZDBKVOContext = (void *)&kRZDBKVOContext;
 - (void)rz_unbindKey:(NSString *)key fromKeyPath:(NSString *)foreignKeyPath ofObject:(id)object
 {
     [object rz_removeTarget:self action:@selector(rz_observeBoundKeyChange:) boundKey:key forKeyPath:foreignKeyPath];
-}
-
-@end
-
-#pragma mark - RZDBObservableObject implementation
-
-@implementation RZDBObservableObject
-
-- (void)dealloc
-{
-    [self rz_cleanupObservers];
 }
 
 @end

--- a/Tests/RZDBTests/RZDBTests.m
+++ b/Tests/RZDBTests/RZDBTests.m
@@ -10,9 +10,6 @@
 
 #import "RZDataBinding.h"
 
-/**
- *  Change the base class to RZDBObservableObject to run tests with RZDB_AUTOMATIC_CLEANUP disabled
- */
 @interface RZDBTestObject : NSObject
 
 @property (copy, nonatomic) NSString *string;
@@ -42,6 +39,13 @@
     _string = [string copy];
     self.setStringCalls++;
 }
+
+#if !RZDB_AUTOMATIC_CLEANUP
+- (void)dealloc
+{
+    [self rz_cleanupObservers];
+}
+#endif
 
 @end
 


### PR DESCRIPTION
#19 

- Removed `RZDBObservableObject` since it is unlikely anyone will/can use this as a base class in most cases.

- Exposed `rz_cleanupObservers` when `RZDB_AUTOMATIC_CLEANUP` is disabled.