### PR TITLE
Feature/jvisenti/gh 35 smart kvo options

### DIFF
--- a/RZDataBinding/NSObject+RZDataBinding.m
+++ b/RZDataBinding/NSObject+RZDataBinding.m
@@ -116,7 +116,11 @@ static void* const kRZDBKVOContext = (void *)&kRZDBKVOContext;
     NSParameterAssert(target);
     NSParameterAssert(action);
 
-    NSKeyValueObservingOptions observationOptions = NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld;
+    NSKeyValueObservingOptions observationOptions = kNilOptions;
+
+    if ( [target methodSignatureForSelector:action].numberOfArguments > 2 ) {
+        observationOptions |= NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld;
+    }
 
     if ( callImmediately ) {
         observationOptions |= NSKeyValueObservingOptionInitial;
@@ -157,7 +161,7 @@ static void* const kRZDBKVOContext = (void *)&kRZDBKVOContext;
             [NSException raise:NSInvalidArgumentException format:@"RZDataBinding cannot bind key:%@ to key path:%@ of object:%@. Reason: %@", key, foreignKeyPath, [object description], exception.reason];
         }
         
-        [object rz_addTarget:self action:@selector(rz_observeBoundKeyChange:) boundKey:key bindingTransform:bindingTransform forKeyPath:foreignKeyPath withOptions:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld];
+        [object rz_addTarget:self action:@selector(rz_observeBoundKeyChange:) boundKey:key bindingTransform:bindingTransform forKeyPath:foreignKeyPath withOptions:NSKeyValueObservingOptionNew];
     }
 }
 

--- a/Tests/RZDBTests/RZDBTests.m
+++ b/Tests/RZDBTests/RZDBTests.m
@@ -122,11 +122,13 @@
 
     for ( NSUInteger i = 0; i < 500000; i++ ) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            if ( arc4random() % 2 == 0 ) {
-                [testObj rz_addTarget:observer action:@selector(testCallback) forKeyPathChange:RZDB_KP_OBJ(testObj, string)];
-            }
-            else {
-                [testObj rz_removeTarget:observer action:@selector(testCallback) forKeyPathChange:RZDB_KP_OBJ(testObj, string)];
+            @autoreleasepool {
+                if ( arc4random() % 2 == 0 ) {
+                    [testObj rz_addTarget:observer action:@selector(testCallback) forKeyPathChange:RZDB_KP_OBJ(testObj, string)];
+                }
+                else {
+                    [testObj rz_removeTarget:observer action:@selector(testCallback) forKeyPathChange:RZDB_KP_OBJ(testObj, string)];
+                }
             }
         });
     }
@@ -210,8 +212,11 @@
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [RZDBCoalesce begin];
         for ( NSUInteger i = 0; i < 5000; i++ ) {
-            RZDBTestObject *t = [testObjects objectAtIndex:arc4random() % testObjects.count];
-            t.string = @"New Value";
+            @autoreleasepool {
+                RZDBTestObject *t = [testObjects objectAtIndex:arc4random() % testObjects.count];
+                t.string = @"New Value";
+            }
+
         }
         [RZDBCoalesce commit];
 


### PR DESCRIPTION
For issue #35 

- `rz_addTarget:action:` only uses `NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld` when the action requires a change dict

-  `rz_bindKey:` no longer unnecessarily uses `NSKeyValueObservingOptionOld`