### PR TITLE
Feature/jvisenti/gh 22 multi registration call immediately

### DIFF
--- a/RZDataBinding/NSObject+RZDataBinding.h
+++ b/RZDataBinding/NSObject+RZDataBinding.h
@@ -109,6 +109,18 @@ OBJC_EXTERN NSString* const kRZDBChangeKeyKeyPath;
 - (void)rz_addTarget:(id)target action:(SEL)action forKeyPathChanges:(NSArray *)keyPaths;
 
 /**
+ *  A convenience method that calls rz_addTarget:action:forKeyPathChange: for each keyPath in the keyPaths array.
+ *
+ *  @param target   The object on which to call the action selector. Must be non-nil. This object is not retained.
+ *  @param action   The selector to call on the target. Must not be NULL. See rz_addTarget documentation for more details.
+ *  @param keyPaths An array of key paths that should trigger an action. Each key path must be KVC compliant.
+ *  @param callImmediately If YES, the action is also called immediately before this method returns. If the action takes no arguments, it will be called once. If the action takes a change dictonary parameter, it will be called once for each keypath, with the appropriate change dict. Note that in this case the dictionary will not contain a value for kRZDBChangeKeyOld.
+ *
+ *  @see RZDB_KP macro for creating keypaths.
+ */
+- (void)rz_addTarget:(id)target action:(SEL)action forKeyPathChanges:(NSArray *)keyPaths callImmediately:(BOOL)callImmediately;
+
+/**
  *  Removes previously registered target/action pairs so that the actions are no longer called when the receiver changes value for keyPath.
  *
  *  @param target  The target to remove. Must be non-nil.

--- a/RZDataBinding/NSObject+RZDataBinding.m
+++ b/RZDataBinding/NSObject+RZDataBinding.m
@@ -127,9 +127,24 @@ static void* const kRZDBKVOContext = (void *)&kRZDBKVOContext;
 
 - (void)rz_addTarget:(id)target action:(SEL)action forKeyPathChanges:(NSArray *)keyPaths
 {
+    [self rz_addTarget:target action:action forKeyPathChanges:keyPaths callImmediately:NO];
+}
+
+- (void)rz_addTarget:(id)target action:(SEL)action forKeyPathChanges:(NSArray *)keyPaths callImmediately:(BOOL)callImmediately
+{
+    BOOL callMultiple = NO;
+
+    if ( callImmediately ) {
+        callMultiple = [target methodSignatureForSelector:action].numberOfArguments > 2;
+    }
+
     [keyPaths enumerateObjectsUsingBlock:^(NSString *keyPath, NSUInteger idx, BOOL *stop) {
-        [self rz_addTarget:target action:action forKeyPathChange:keyPath callImmediately:NO];
+        [self rz_addTarget:target action:action forKeyPathChange:keyPath callImmediately:callMultiple];
     }];
+
+    if ( callImmediately && !callMultiple ) {
+        ((void(*)(id, SEL))objc_msgSend)(target, action);
+    }
 }
 
 - (void)rz_removeTarget:(id)target action:(SEL)action forKeyPathChange:(NSString *)keyPath

--- a/Tests/RZDBTests/RZDBTests.m
+++ b/Tests/RZDBTests/RZDBTests.m
@@ -107,11 +107,16 @@
     RZDBTestObject *testObj = [RZDBTestObject new];
     RZDBTestObject *observer = [RZDBTestObject new];
     
-    [testObj rz_addTarget:observer action:@selector(changeCallback) forKeyPathChanges:@[RZDB_KP_OBJ(testObj, string), RZDB_KP_OBJ(testObj, callbackCalls)]];
+    [testObj rz_addTarget:observer action:@selector(changeCallback) forKeyPathChanges:@[RZDB_KP_OBJ(testObj, string), RZDB_KP_OBJ(testObj, callbackCalls)] callImmediately:YES];
     
     testObj.string = @"test";
     testObj.callbackCalls = 0;
     
+    XCTAssertTrue(observer.callbackCalls == 3, @"Callback called incorrect number of times. Expected:2 Actual:%i", (int)observer.callbackCalls);
+
+    observer.callbackCalls = 0;
+    [testObj rz_addTarget:observer action:@selector(changeCallbackWithDict:) forKeyPathChanges:@[RZDB_KP_OBJ(testObj, string), RZDB_KP_OBJ(testObj, callbackCalls)] callImmediately:YES];
+
     XCTAssertTrue(observer.callbackCalls == 2, @"Callback called incorrect number of times. Expected:2 Actual:%i", (int)observer.callbackCalls);
 }
 


### PR DESCRIPTION
For issue #22 

- Added a `callImmediately:` version of `rz_addTarget:action:forKeyPathChanges:`
    - If the action requires a change dict, it is called once for each key path with the appropriate change dictionary.
    - If the action doesn't require a change dict, it is called once.