### PR TITLE
2.0 Release

### DIFF
--- a/Example/RZDBDemo.xcodeproj/project.pbxproj
+++ b/Example/RZDBDemo.xcodeproj/project.pbxproj
@@ -9,7 +9,9 @@
 /* Begin PBXBuildFile section */
 		D41F4FDB1A5346EF00D0BA2D /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = D41F4FD71A5346EF00D0BA2D /* LaunchScreen.xib */; };
 		D41F4FDC1A5346EF00D0BA2D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D41F4FD91A5346EF00D0BA2D /* Main.storyboard */; };
-		D4B8C89F1A5C3C0E00148F68 /* NSObject+RZDataBinding.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B8C89E1A5C3C0E00148F68 /* NSObject+RZDataBinding.m */; };
+		D4AD92B31AD5784C00AA80D1 /* NSObject+RZDataBinding.m in Sources */ = {isa = PBXBuildFile; fileRef = D4AD92AC1AD5784C00AA80D1 /* NSObject+RZDataBinding.m */; };
+		D4AD92B41AD5784C00AA80D1 /* RZDBCoalesce.m in Sources */ = {isa = PBXBuildFile; fileRef = D4AD92AF1AD5784C00AA80D1 /* RZDBCoalesce.m */; };
+		D4AD92B51AD5784C00AA80D1 /* RZDBTransforms.m in Sources */ = {isa = PBXBuildFile; fileRef = D4AD92B21AD5784C00AA80D1 /* RZDBTransforms.m */; };
 		D4B8C8A31A5C47EC00148F68 /* UIColor+RZHexColor.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B8C8A21A5C47EC00148F68 /* UIColor+RZHexColor.m */; };
 		D4B8C8A61A5C4A0700148F68 /* UIImage+RZColor.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B8C8A51A5C4A0700148F68 /* UIImage+RZColor.m */; };
 		D4B8C8A91A5C57B400148F68 /* RZUserViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B8C8A81A5C57B400148F68 /* RZUserViewController.m */; };
@@ -26,9 +28,14 @@
 /* Begin PBXFileReference section */
 		D41F4FD81A5346EF00D0BA2D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = SOURCE_ROOT; };
 		D41F4FDA1A5346EF00D0BA2D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = SOURCE_ROOT; };
-		D4ABA1C01AB9F90800220A1A /* RZDBMacros.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RZDBMacros.h; path = ../RZDataBinding/RZDBMacros.h; sourceTree = "<group>"; };
-		D4B8C89D1A5C3C0E00148F68 /* NSObject+RZDataBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSObject+RZDataBinding.h"; path = "../RZDataBinding/NSObject+RZDataBinding.h"; sourceTree = "<group>"; };
-		D4B8C89E1A5C3C0E00148F68 /* NSObject+RZDataBinding.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RZDataBinding.m"; path = "../RZDataBinding/NSObject+RZDataBinding.m"; sourceTree = "<group>"; };
+		D4AD92AB1AD5784C00AA80D1 /* NSObject+RZDataBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSObject+RZDataBinding.h"; path = "../RZDataBinding/NSObject+RZDataBinding.h"; sourceTree = "<group>"; };
+		D4AD92AC1AD5784C00AA80D1 /* NSObject+RZDataBinding.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RZDataBinding.m"; path = "../RZDataBinding/NSObject+RZDataBinding.m"; sourceTree = "<group>"; };
+		D4AD92AD1AD5784C00AA80D1 /* RZDataBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RZDataBinding.h; path = ../RZDataBinding/RZDataBinding.h; sourceTree = "<group>"; };
+		D4AD92AE1AD5784C00AA80D1 /* RZDBCoalesce.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RZDBCoalesce.h; path = ../RZDataBinding/RZDBCoalesce.h; sourceTree = "<group>"; };
+		D4AD92AF1AD5784C00AA80D1 /* RZDBCoalesce.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RZDBCoalesce.m; path = ../RZDataBinding/RZDBCoalesce.m; sourceTree = "<group>"; };
+		D4AD92B01AD5784C00AA80D1 /* RZDBMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RZDBMacros.h; path = ../RZDataBinding/RZDBMacros.h; sourceTree = "<group>"; };
+		D4AD92B11AD5784C00AA80D1 /* RZDBTransforms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RZDBTransforms.h; path = ../RZDataBinding/RZDBTransforms.h; sourceTree = "<group>"; };
+		D4AD92B21AD5784C00AA80D1 /* RZDBTransforms.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RZDBTransforms.m; path = ../RZDataBinding/RZDBTransforms.m; sourceTree = "<group>"; };
 		D4B8C8A11A5C47EC00148F68 /* UIColor+RZHexColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIColor+RZHexColor.h"; path = "Utils/UIColor+RZHexColor.h"; sourceTree = "<group>"; };
 		D4B8C8A21A5C47EC00148F68 /* UIColor+RZHexColor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "UIColor+RZHexColor.m"; path = "Utils/UIColor+RZHexColor.m"; sourceTree = "<group>"; };
 		D4B8C8A41A5C4A0700148F68 /* UIImage+RZColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "UIImage+RZColor.h"; path = "Utils/UIImage+RZColor.h"; sourceTree = "<group>"; };
@@ -122,9 +129,14 @@
 		D4C5F4281A39F6CC00CC6FB3 /* RZDataBinding */ = {
 			isa = PBXGroup;
 			children = (
-				D4ABA1C01AB9F90800220A1A /* RZDBMacros.h */,
-				D4B8C89D1A5C3C0E00148F68 /* NSObject+RZDataBinding.h */,
-				D4B8C89E1A5C3C0E00148F68 /* NSObject+RZDataBinding.m */,
+				D4AD92AB1AD5784C00AA80D1 /* NSObject+RZDataBinding.h */,
+				D4AD92AC1AD5784C00AA80D1 /* NSObject+RZDataBinding.m */,
+				D4AD92AD1AD5784C00AA80D1 /* RZDataBinding.h */,
+				D4AD92AE1AD5784C00AA80D1 /* RZDBCoalesce.h */,
+				D4AD92AF1AD5784C00AA80D1 /* RZDBCoalesce.m */,
+				D4AD92B01AD5784C00AA80D1 /* RZDBMacros.h */,
+				D4AD92B11AD5784C00AA80D1 /* RZDBTransforms.h */,
+				D4AD92B21AD5784C00AA80D1 /* RZDBTransforms.m */,
 			);
 			name = RZDataBinding;
 			sourceTree = "<group>";
@@ -213,13 +225,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				D4C5F4051A39F5A100CC6FB3 /* RZTableViewController.m in Sources */,
+				D4AD92B41AD5784C00AA80D1 /* RZDBCoalesce.m in Sources */,
 				D4C5F4021A39F5A100CC6FB3 /* RZAppDelegate.m in Sources */,
-				D4B8C89F1A5C3C0E00148F68 /* NSObject+RZDataBinding.m in Sources */,
 				D4B8C8A91A5C57B400148F68 /* RZUserViewController.m in Sources */,
 				D4C5F4241A39F64E00CC6FB3 /* RZUser.m in Sources */,
 				D4C5F3FF1A39F5A100CC6FB3 /* main.m in Sources */,
+				D4AD92B51AD5784C00AA80D1 /* RZDBTransforms.m in Sources */,
 				D4B8C8A61A5C4A0700148F68 /* UIImage+RZColor.m in Sources */,
 				D4B8C8A31A5C47EC00148F68 /* UIColor+RZHexColor.m in Sources */,
+				D4AD92B31AD5784C00AA80D1 /* NSObject+RZDataBinding.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/RZDBDemo/RZTableViewController.m
+++ b/Example/RZDBDemo/RZTableViewController.m
@@ -9,7 +9,7 @@
 #import "RZTableViewController.h"
 #import "RZUserViewController.h"
 
-#import "NSObject+RZDataBinding.h"
+#import "RZDataBinding.h"
 #import "UIImage+RZColor.h"
 #import "UIColor+RZHexColor.h"
 
@@ -52,12 +52,12 @@
     
     [cell.textLabel rz_bindKey:RZDB_KP(UILabel, text) toKeyPath:RZDB_KP(RZUser, fullName) ofObject:user];
     
-    [cell.imageView rz_bindKey:RZDB_KP(UIImageView, image) toKeyPath:RZDB_KP(RZUser, favoriteColorHex) ofObject:user withFunction:^id(id value) {
+    [cell.imageView rz_bindKey:RZDB_KP(UIImageView, image) toKeyPath:RZDB_KP(RZUser, favoriteColorHex) ofObject:user withTransform:^id(id value) {
         UIColor *color = [UIColor rz_hexColor:(uint32_t)[value integerValue]];
         return [UIImage rz_imageWithColor:color size:CGSizeMake(35.0f, 35.0f)];
     }];
     
-    [cell.detailTextLabel rz_bindKey:RZDB_KP(UILabel, text) toKeyPath:RZDB_KP(RZUser, age) ofObject:user withFunction:^id(id value) {
+    [cell.detailTextLabel rz_bindKey:RZDB_KP(UILabel, text) toKeyPath:RZDB_KP(RZUser, age) ofObject:user withTransform:^id(id value) {
         return [value stringValue];
     }];
     

--- a/Example/RZDBDemo/RZUser.m
+++ b/Example/RZDBDemo/RZUser.m
@@ -8,7 +8,7 @@
 
 #import "RZUser.h"
 
-#import "NSObject+RZDataBinding.h"
+#import "RZDataBinding.h"
 
 @interface RZUser ()
 

--- a/Example/RZDBDemo/RZUserViewController.m
+++ b/Example/RZDBDemo/RZUserViewController.m
@@ -8,7 +8,7 @@
 
 #import "RZUserViewController.h"
 
-#import "NSObject+RZDataBinding.h"
+#import "RZDataBinding.h"
 #import "UIColor+RZHexColor.h"
 
 @implementation RZUserViewController
@@ -21,7 +21,7 @@
     self.lastNameField.text = self.user.lastName;
     
     self.ageStepper.value = self.user.age;
-    [self.ageLabel rz_bindKey:RZDB_KP(UILabel, text) toKeyPath:RZDB_KP(UIStepper, value) ofObject:self.ageStepper withFunction:^id(id value) {
+    [self.ageLabel rz_bindKey:RZDB_KP(UILabel, text) toKeyPath:RZDB_KP(UIStepper, value) ofObject:self.ageStepper withTransform:^id(id value) {
         return [value stringValue];
     }];
     
@@ -31,7 +31,7 @@
     self.gSlider.value = ((self.user.favoriteColorHex & 0xFF00) >> 8) / 255.0f;
     self.bSlider.value = (self.user.favoriteColorHex & 0xFF) / 255.0f;
 
-    [self.colorView rz_bindKey:RZDB_KP(UIView, backgroundColor) toKeyPath:RZDB_KP(RZUser, favoriteColorHex) ofObject:self.user withFunction:^id(id value) {
+    [self.colorView rz_bindKey:RZDB_KP(UIView, backgroundColor) toKeyPath:RZDB_KP(RZUser, favoriteColorHex) ofObject:self.user withTransform:^id(id value) {
         return [UIColor rz_hexColor:(uint32_t)[value integerValue]];
     }];
     

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ The demo shows a basic usage of RZDataBinding, but is by no means the canonical 
 // If the method has a parameter, the dictionary will contain values for the appropriate 
 // RZDBChangeKeys. If keys are absent, they can be assumed to be nil. Values will not be NSNull.
 - (void)rz_addTarget:(id)target
-        action:(SEL)action
-        forKeyPathChange:(NSString *)keyPath;
+              action:(SEL)action
+    forKeyPathChange:(NSString *)keyPath;
 ```
 
 **Bind values of two objects together either directly or with a function:**
@@ -47,16 +47,16 @@ The demo shows a basic usage of RZDataBinding, but is by no means the canonical 
 // Binds the value of a given key of the receiver to the value of a key path of another object. 
 // When the key path of the object changes, the bound key of the receiver is also changed.
 - (void)rz_bindKey:(NSString *)key
-        toKeyPath:(NSString *)foreignKeyPath
-        ofObject:(id)object;
+         toKeyPath:(NSString *)foreignKeyPath
+          ofObject:(id)object;
 
 // Same as the above method, but the binding function is first applied 
 // to the changed value before setting the value of the bound key.
 // If nil, the identity function is assumed, making it identical to regular rz_bindKey.
 - (void)rz_bindKey:(NSString *)key 
-        toKeyPath:(NSString *)foreignKeyPath 
-        ofObject:(id)object
-        withFunction:(RZDBKeyBindingFunction)bindingFunction;
+         toKeyPath:(NSString *)foreignKeyPath 
+          ofObject:(id)object
+      withFunction:(RZDBKeyBindingFunction)bindingFunction;
 ```
 Targets can be removed and keys unbound with corresponding removal methods, but unlike with standard KVO, you are not obligated to do so. RZDataBinding will automatically cleanup observers before objects are deallocated. 
 

--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ static void* const MyKVOContext = (void *)&MyKVOContext;
 - (void)setupKVO
 {
     [self.user addObserver:self
-               forKeyPath:@"name"
-               options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew
-               context:MyKVOContext]; 
+                forKeyPath:@"name"
+                   options:NSKeyValueObservingOptionOld | NSKeyValueObservingOptionNew
+                   context:MyKVOContext]; 
                   
     [self.user addObserver:self
-               forKeyPath:@"preferences"
-               options:kNilOptions
-               context:MyKVOContext];
+                forKeyPath:@"preferences"
+                   options:kNilOptions
+                   context:MyKVOContext];
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath
@@ -111,12 +111,12 @@ static void* const MyKVOContext = (void *)&MyKVOContext;
 - (void)setupKVO
 {
     [self.user rz_addTarget:self 
-               action:@selector(nameChanged:) 
-               forKeyPathChange:@"name"];
+                     action:@selector(nameChanged:) 
+           forKeyPathChange:@"name"];
     
     [self.user rz_addTarget:self.collectionView 
-               action:@selector(reloadData) 
-               forKeyPathChange:@"preferences"];
+                     action:@selector(reloadData) 
+           forKeyPathChange:@"preferences"];
 }
 ```
 Aside from the obvious reduction in code, the RZDataBinding implementation demonstrates several other wins:

--- a/RZDataBinding.podspec
+++ b/RZDataBinding.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "RZDataBinding"
-  s.version          = "1.3.0"
+  s.version          = "2.0.0"
   s.summary          = "KVO extensions that help maintain data integrity in your iOS or OSX app"
   s.description      = <<-DESC
                        Add callbacks when key paths of objects change, or bind values of two objects together either directly or using a function. Automatically cleanup before deallocation to avoid those nasty KVO observation info leaks.

--- a/RZDataBinding/NSObject+RZDataBinding.h
+++ b/RZDataBinding/NSObject+RZDataBinding.h
@@ -109,6 +109,18 @@ OBJC_EXTERN NSString* const kRZDBChangeKeyKeyPath;
 - (void)rz_addTarget:(id)target action:(SEL)action forKeyPathChanges:(NSArray *)keyPaths;
 
 /**
+ *  A convenience method that calls rz_addTarget:action:forKeyPathChange: for each keyPath in the keyPaths array.
+ *
+ *  @param target   The object on which to call the action selector. Must be non-nil. This object is not retained.
+ *  @param action   The selector to call on the target. Must not be NULL. See rz_addTarget documentation for more details.
+ *  @param keyPaths An array of key paths that should trigger an action. Each key path must be KVC compliant.
+ *  @param callImmediately If YES, the action is also called immediately before this method returns. If the action takes no arguments, it will be called once. If the action takes a change dictonary parameter, it will be called once for each keypath, with the appropriate change dict. Note that in this case the dictionary will not contain a value for kRZDBChangeKeyOld.
+ *
+ *  @see RZDB_KP macro for creating keypaths.
+ */
+- (void)rz_addTarget:(id)target action:(SEL)action forKeyPathChanges:(NSArray *)keyPaths callImmediately:(BOOL)callImmediately;
+
+/**
  *  Removes previously registered target/action pairs so that the actions are no longer called when the receiver changes value for keyPath.
  *
  *  @param target  The target to remove. Must be non-nil.

--- a/RZDataBinding/NSObject+RZDataBinding.h
+++ b/RZDataBinding/NSObject+RZDataBinding.h
@@ -26,8 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-#import <Foundation/Foundation.h>
-#import "RZDBMacros.h"
+#import "RZDBTransforms.h"
 
 #pragma mark - Constants and Definitions
 
@@ -50,15 +49,6 @@ OBJC_EXTERN NSString* const kRZDBChangeKeyNew;
  *  The value for this key is the key path that changed value. This key is always present.
  */
 OBJC_EXTERN NSString* const kRZDBChangeKeyKeyPath;
-
-/**
- *  A function that takes a value as a parameter and returns an object.
- *
- *  @param value The value that just changed on a foreign object for a bound key path.
- *
- *  @return The value to set for the bound key. Ideally the returned value should depend solely on the input value.
- */
-typedef id (^RZDBKeyBindingFunction)(id value);
 
 /**
  *  Set this to 1 (recommended) to enable automatic cleanup of observers on object deallocation.
@@ -137,21 +127,27 @@ typedef id (^RZDBKeyBindingFunction)(id value);
  *  @param foreignKeyPath A key path of another object to which the receiver's key value should be bound. Must be KVC compliant.
  *  @param object         An object with a key path that the receiver should bind to.
  *
+ *  @note If binding a primitive-type key to a keypath that may hit a nil object, you MUST use 
+ *  rz_bindKey:toKeyPath:ofObject:withTransform: instead. This is because attempting to set a nil
+ *  value to a primitive-type using KVC causes a crash. In this case it may be helpful to use 
+ *  one of the default RZDBTransforms.
+ *
  *  @see RZDB_KP macro for creating keypaths.
  */
 - (void)rz_bindKey:(NSString *)key toKeyPath:(NSString *)foreignKeyPath ofObject:(id)object;
 
 /**
- *  Binds the value of a given key of the receiver to the value of a key path of another object. When the key path of the object changes, the binding function is invoked and the bound key of the receiver is set to the function's return value. The receiver's value for the key will be set before this method returns.
+ *  Binds the value of a given key of the receiver to the value of a key path of another object. When the key path of the object changes, the binding transform is invoked and the bound key of the receiver is set to the transform's return value. The receiver's value for the key will be set before this method returns.
  *
  *  @param key            The receiver's key whose value should be bound to the value of a foreign key path. Must be KVC compliant.
  *  @param foreignKeyPath A key path of another object to which the receiver's key value should be bound. Must be KVC compliant.
  *  @param object         An object with a key path that the receiver should bind to.
- *  @param bindingFunction The function to apply to changed values before setting the value of the bound key. If nil, the identity function is assumed, making this method identical to regular rz_bindKey.
+ *  @param bindingTransform The transform to apply to changed values before setting the value of the bound key. If nil, the identity transform is assumed, making this method identical to regular rz_bindKey:.
+ *  You may use the constant RZDBTransforms provided for convenience.
  *
- *  @see RZDB_KP macro for creating keypaths.
+ *  @see RZDB_KP macro for creating keypaths, and RZDBTransforms for constant transforms.
  */
-- (void)rz_bindKey:(NSString *)key toKeyPath:(NSString *)foreignKeyPath ofObject:(id)object withFunction:(RZDBKeyBindingFunction)bindingFunction;
+- (void)rz_bindKey:(NSString *)key toKeyPath:(NSString *)foreignKeyPath ofObject:(id)object withTransform:(RZDBKeyBindingTransform)bindingTransform;
 
 /**
  *  Unbinds the given key of the receiver from the key path of another object.

--- a/RZDataBinding/NSObject+RZDataBinding.m
+++ b/RZDataBinding/NSObject+RZDataBinding.m
@@ -65,7 +65,6 @@ static void* const kRZDBKVOContext = (void *)&kRZDBKVOContext;
 - (void)rz_removeTarget:(id)target action:(SEL)action boundKey:(NSString *)boundKey forKeyPath:(NSString *)keyPath;
 - (void)rz_observeBoundKeyChange:(NSDictionary *)change;
 - (void)rz_setBoundKey:(NSString *)key withValue:(id)value transform:(RZDBKeyBindingTransform)transform;
-- (void)rz_cleanupObservers;
 
 @end
 
@@ -165,17 +164,6 @@ static void* const kRZDBKVOContext = (void *)&kRZDBKVOContext;
 - (void)rz_unbindKey:(NSString *)key fromKeyPath:(NSString *)foreignKeyPath ofObject:(id)object
 {
     [object rz_removeTarget:self action:@selector(rz_observeBoundKeyChange:) boundKey:key forKeyPath:foreignKeyPath];
-}
-
-@end
-
-#pragma mark - RZDBObservableObject implementation
-
-@implementation RZDBObservableObject
-
-- (void)dealloc
-{
-    [self rz_cleanupObservers];
 }
 
 @end

--- a/RZDataBinding/NSObject+RZDataBinding.m
+++ b/RZDataBinding/NSObject+RZDataBinding.m
@@ -127,9 +127,24 @@ static void* const kRZDBKVOContext = (void *)&kRZDBKVOContext;
 
 - (void)rz_addTarget:(id)target action:(SEL)action forKeyPathChanges:(NSArray *)keyPaths
 {
+    [self rz_addTarget:target action:action forKeyPathChanges:keyPaths callImmediately:NO];
+}
+
+- (void)rz_addTarget:(id)target action:(SEL)action forKeyPathChanges:(NSArray *)keyPaths callImmediately:(BOOL)callImmediately
+{
+    BOOL callMultiple = NO;
+
+    if ( callImmediately ) {
+        callMultiple = [target methodSignatureForSelector:action].numberOfArguments > 2;
+    }
+
     [keyPaths enumerateObjectsUsingBlock:^(NSString *keyPath, NSUInteger idx, BOOL *stop) {
-        [self rz_addTarget:target action:action forKeyPathChange:keyPath callImmediately:NO];
+        [self rz_addTarget:target action:action forKeyPathChange:keyPath callImmediately:callMultiple];
     }];
+
+    if ( callImmediately && !callMultiple ) {
+        ((void(*)(id, SEL))objc_msgSend)(target, action);
+    }
 }
 
 - (void)rz_removeTarget:(id)target action:(SEL)action forKeyPathChange:(NSString *)keyPath

--- a/RZDataBinding/NSObject+RZDataBinding.m
+++ b/RZDataBinding/NSObject+RZDataBinding.m
@@ -116,7 +116,11 @@ static void* const kRZDBKVOContext = (void *)&kRZDBKVOContext;
     NSParameterAssert(target);
     NSParameterAssert(action);
 
-    NSKeyValueObservingOptions observationOptions = NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld;
+    NSKeyValueObservingOptions observationOptions = kNilOptions;
+
+    if ( [target methodSignatureForSelector:action].numberOfArguments > 2 ) {
+        observationOptions |= NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld;
+    }
 
     if ( callImmediately ) {
         observationOptions |= NSKeyValueObservingOptionInitial;
@@ -172,7 +176,7 @@ static void* const kRZDBKVOContext = (void *)&kRZDBKVOContext;
             [NSException raise:NSInvalidArgumentException format:@"RZDataBinding cannot bind key:%@ to key path:%@ of object:%@. Reason: %@", key, foreignKeyPath, [object description], exception.reason];
         }
         
-        [object rz_addTarget:self action:@selector(rz_observeBoundKeyChange:) boundKey:key bindingTransform:bindingTransform forKeyPath:foreignKeyPath withOptions:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld];
+        [object rz_addTarget:self action:@selector(rz_observeBoundKeyChange:) boundKey:key bindingTransform:bindingTransform forKeyPath:foreignKeyPath withOptions:NSKeyValueObservingOptionNew];
     }
 }
 

--- a/RZDataBinding/RZDBMacros.h
+++ b/RZDataBinding/RZDBMacros.h
@@ -1,13 +1,38 @@
 //
 //  RZDBMacros.h
-//  RZDBTests
 //
 //  Created by Rob Visentin on 3/18/15.
+
+// Copyright 2014 Raizlabs and other contributors
+// http://raizlabs.com/
 //
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
 //
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #ifndef __RZDBMacros__
 #define __RZDBMacros__
+
+////////////////////////////////////////
+////                                ////
+////            Logging             ////
+////                                ////
+////////////////////////////////////////
 
 /**
  *  The method that should be used to log errors in RZDataBinding that are non-fatal,

--- a/RZDataBinding/RZDBTransforms.h
+++ b/RZDataBinding/RZDBTransforms.h
@@ -1,0 +1,81 @@
+//
+//  RZDataBinding.h
+//
+//  Created by Rob Visentin on 4/7/15.
+
+// Copyright 2014 Raizlabs and other contributors
+// http://raizlabs.com/
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+#pragma mark - Definitions
+
+/**
+ *  A transform that takes a value as a parameter and returns an object.
+ *
+ *  @param value The value that just changed on a foreign object for a bound key path.
+ *
+ *  @return The value to set for the bound key. Ideally the returned value should depend solely on the input value.
+ */
+typedef id (^RZDBKeyBindingTransform)(id value);
+
+#pragma mark - Convenience Constants
+
+/**
+ *  If value is nil, returns @(0), otherwise returns value.
+ */
+OBJC_EXTERN RZDBKeyBindingTransform const kRZDBNilToZeroTransform;
+
+/**
+ *  If value is nil, returns @(1), otherwise returns value.
+ */
+OBJC_EXTERN RZDBKeyBindingTransform const kRZDBNilToOneTransform;
+
+/**
+ *  If value is nil, returns NSValue with CGSizeZero, otherwise returns value.
+ */
+OBJC_EXTERN RZDBKeyBindingTransform const kRZDBNilToCGSizeZeroTransform;
+
+/**
+ *  If value is nil, returns NSValue with CGRectZero, otherwise returns value.
+ */
+OBJC_EXTERN RZDBKeyBindingTransform const kRZDBNilToCGRectZeroTransform;
+
+/**
+ *  If value is nil, returns NSValue with CGRectNull, otherwise returns value.
+ */
+OBJC_EXTERN RZDBKeyBindingTransform const kRZDBNilToCGRectNullTransform;
+
+/**
+ *  Returns @(![value boolValue])
+ */
+OBJC_EXTERN RZDBKeyBindingTransform const kRZDBLogicalNegateTransform;
+
+/**
+ *  Returns @(1.0 - [value doubleValue])
+ */
+OBJC_EXTERN RZDBKeyBindingTransform const kRZDBOneMinusTransform;
+
+/**
+ *  Returns @(~[value longLongValue])
+ */
+OBJC_EXTERN RZDBKeyBindingTransform const kRZDBBitwiseComplementTransform;

--- a/RZDataBinding/RZDBTransforms.m
+++ b/RZDataBinding/RZDBTransforms.m
@@ -1,0 +1,71 @@
+//
+//  RZDataBinding.m
+//
+//  Created by Rob Visentin on 4/7/15.
+
+// Copyright 2014 Raizlabs and other contributors
+// http://raizlabs.com/
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import <CoreGraphics/CGGeometry.h>
+
+#import "RZDBTransforms.h"
+
+RZDBKeyBindingTransform const kRZDBNilToZeroTransform = ^(id value) {
+    return (value == nil) ? @(0) : value;
+};
+
+RZDBKeyBindingTransform const kRZDBNilToOneTransform = ^(id value) {
+    return (value == nil) ? @(1) : value;
+};
+
+RZDBKeyBindingTransform const kRZDBNilToCGSizeZeroTransform = ^(id value) {
+    if ( value == nil ) {
+        value = [NSValue valueWithBytes:&CGSizeZero objCType:@encode(CGSize)];
+    }
+    return value;
+};
+
+RZDBKeyBindingTransform const kRZDBNilToCGRectZeroTransform = ^(id value) {
+    if ( value == nil ) {
+        value = [NSValue valueWithBytes:&CGRectZero objCType:@encode(CGRect)];
+    }
+    return value;
+};
+
+RZDBKeyBindingTransform const kRZDBNilToCGRectNullTransform = ^(id value) {
+    if ( value == nil ) {
+        value = [NSValue valueWithBytes:&CGRectNull objCType:@encode(CGRect)];
+    }
+    return value;
+};
+
+RZDBKeyBindingTransform const kRZDBLogicalNegateTransform = ^(id value) {
+    return @(![value boolValue]);
+};
+
+RZDBKeyBindingTransform const kRZDBOneMinusTransform = ^(id value) {
+    return @(1.0 - [value doubleValue]);
+};
+
+RZDBKeyBindingTransform const kRZDBBitwiseComplementTransform = ^(id value) {
+    return @(~[value longLongValue]);
+};

--- a/RZDataBinding/RZDataBinding.h
+++ b/RZDataBinding/RZDataBinding.h
@@ -1,0 +1,31 @@
+//
+//  RZDataBinding.h
+//
+//  Created by Rob Visentin on 4/7/15.
+
+// Copyright 2014 Raizlabs and other contributors
+// http://raizlabs.com/
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#import "RZDBMacros.h"
+#import "RZDBTransforms.h"
+#import "RZDBCoalesce.h"
+#import "NSObject+RZDataBinding.h"

--- a/Tests/RZDBTests.xcodeproj/project.pbxproj
+++ b/Tests/RZDBTests.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		D49BB2C619CB866D000DEC83 /* RZDBTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D49BB2C519CB866D000DEC83 /* RZDBTests.m */; };
+		D4AA6DB11AD4C5F600BA2A9E /* RZDBTransforms.m in Sources */ = {isa = PBXBuildFile; fileRef = D4AA6DAF1AD4C5F600BA2A9E /* RZDBTransforms.m */; };
 		D4B8C8321A5C2B8F00148F68 /* NSObject+RZDataBinding.m in Sources */ = {isa = PBXBuildFile; fileRef = D4B8C8311A5C2B8F00148F68 /* NSObject+RZDataBinding.m */; };
 		D4C790A51AD2C6D000ACD1CE /* RZDBCoalesce.m in Sources */ = {isa = PBXBuildFile; fileRef = D4C790A41AD2C6D000ACD1CE /* RZDBCoalesce.m */; };
 /* End PBXBuildFile section */
@@ -16,6 +17,9 @@
 		D49BB2C019CB866D000DEC83 /* RZDBTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RZDBTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D49BB2C419CB866D000DEC83 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D49BB2C519CB866D000DEC83 /* RZDBTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RZDBTests.m; sourceTree = "<group>"; };
+		D4AA6DAE1AD4C54C00BA2A9E /* RZDataBinding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RZDataBinding.h; path = ../RZDataBinding/RZDataBinding.h; sourceTree = "<group>"; };
+		D4AA6DAF1AD4C5F600BA2A9E /* RZDBTransforms.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RZDBTransforms.m; path = ../RZDataBinding/RZDBTransforms.m; sourceTree = "<group>"; };
+		D4AA6DB01AD4C5F600BA2A9E /* RZDBTransforms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RZDBTransforms.h; path = ../RZDataBinding/RZDBTransforms.h; sourceTree = "<group>"; };
 		D4ABA1BE1AB9E5D200220A1A /* RZDBMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RZDBMacros.h; path = ../RZDataBinding/RZDBMacros.h; sourceTree = "<group>"; };
 		D4B8C8301A5C2B8F00148F68 /* NSObject+RZDataBinding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSObject+RZDataBinding.h"; path = "../RZDataBinding/NSObject+RZDataBinding.h"; sourceTree = "<group>"; };
 		D4B8C8311A5C2B8F00148F68 /* NSObject+RZDataBinding.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSObject+RZDataBinding.m"; path = "../RZDataBinding/NSObject+RZDataBinding.m"; sourceTree = "<group>"; };
@@ -37,11 +41,14 @@
 		D49BB2B519CB862A000DEC83 = {
 			isa = PBXGroup;
 			children = (
+				D4AA6DAE1AD4C54C00BA2A9E /* RZDataBinding.h */,
 				D4ABA1BE1AB9E5D200220A1A /* RZDBMacros.h */,
-				D4B8C8301A5C2B8F00148F68 /* NSObject+RZDataBinding.h */,
-				D4B8C8311A5C2B8F00148F68 /* NSObject+RZDataBinding.m */,
+				D4AA6DB01AD4C5F600BA2A9E /* RZDBTransforms.h */,
+				D4AA6DAF1AD4C5F600BA2A9E /* RZDBTransforms.m */,
 				D4C790A31AD2C6D000ACD1CE /* RZDBCoalesce.h */,
 				D4C790A41AD2C6D000ACD1CE /* RZDBCoalesce.m */,
+				D4B8C8301A5C2B8F00148F68 /* NSObject+RZDataBinding.h */,
+				D4B8C8311A5C2B8F00148F68 /* NSObject+RZDataBinding.m */,
 				D49BB2C219CB866D000DEC83 /* RZDBTests */,
 				D49BB2C119CB866D000DEC83 /* Products */,
 			);
@@ -139,6 +146,7 @@
 			files = (
 				D49BB2C619CB866D000DEC83 /* RZDBTests.m in Sources */,
 				D4C790A51AD2C6D000ACD1CE /* RZDBCoalesce.m in Sources */,
+				D4AA6DB11AD4C5F600BA2A9E /* RZDBTransforms.m in Sources */,
 				D4B8C8321A5C2B8F00148F68 /* NSObject+RZDataBinding.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/RZDBTests/RZDBTests.m
+++ b/Tests/RZDBTests/RZDBTests.m
@@ -10,9 +10,6 @@
 
 #import "RZDataBinding.h"
 
-/**
- *  Change the base class to RZDBObservableObject to run tests with RZDB_AUTOMATIC_CLEANUP disabled
- */
 @interface RZDBTestObject : NSObject
 
 @property (copy, nonatomic) NSString *string;
@@ -42,6 +39,13 @@
     _string = [string copy];
     self.setStringCalls++;
 }
+
+#if !RZDB_AUTOMATIC_CLEANUP
+- (void)dealloc
+{
+    [self rz_cleanupObservers];
+}
+#endif
 
 @end
 

--- a/Tests/RZDBTests/RZDBTests.m
+++ b/Tests/RZDBTests/RZDBTests.m
@@ -6,9 +6,9 @@
 //
 
 @import XCTest;
+@import CoreGraphics.CGGeometry;
 
-#import "NSObject+RZDataBinding.h"
-#import "RZDBCoalesce.h"
+#import "RZDataBinding.h"
 
 /**
  *  Change the base class to RZDBObservableObject to run tests with RZDB_AUTOMATIC_CLEANUP disabled
@@ -255,18 +255,18 @@
     XCTAssertTrue(observer.setStringCalls == 2, @"Binding triggered incorrect number of times. Expected:2 Actual:%i", (int)observer.setStringCalls);
 }
 
-- (void)testKeyBindingWithFunction
+- (void)testKeyBindingWithTransform
 {
     RZDBTestObject *testObj = [RZDBTestObject new];
     RZDBTestObject *observer = [RZDBTestObject new];
     
     testObj.callbackCalls = 5;
     
-    [observer rz_bindKey:RZDB_KP_OBJ(observer, callbackCalls) toKeyPath:RZDB_KP_OBJ(testObj, callbackCalls) ofObject:testObj withFunction:^id (id value) {
+    [observer rz_bindKey:RZDB_KP_OBJ(observer, callbackCalls) toKeyPath:RZDB_KP_OBJ(testObj, callbackCalls) ofObject:testObj withTransform:^id (id value) {
         return @([(NSNumber *)value integerValue] + 100);
     }];
     
-    XCTAssertTrue(observer.callbackCalls == 105, @"Key binding function was not properly applied before setting value for key when key path changed.");
+    XCTAssertTrue(observer.callbackCalls == 105, @"Key binding transform was not properly applied before setting value for key when key path changed.");
     
     [observer rz_unbindKey:RZDB_KP_OBJ(observer, callbackCalls) fromKeyPath:RZDB_KP_OBJ(testObj, callbackCalls) ofObject:testObj];
     testObj.callbackCalls = 100;
@@ -285,6 +285,48 @@
     obj1.string = @"test";
     
     XCTAssertTrue([obj3.string isEqualToString:obj2.string] && [obj2.string isEqualToString:obj1.string], @"Binding chain failed--values not equal");
+}
+
+- (void)testTransformConstants
+{
+    id value = nil;
+
+    value = kRZDBNilToZeroTransform(value);
+    XCTAssertTrue([value isEqual:@(0)]);
+
+    value = nil;
+    value = kRZDBNilToOneTransform(value);
+    XCTAssertTrue([value isEqual:@(1)]);
+
+    value = nil;
+    value = kRZDBNilToCGSizeZeroTransform(value);
+    CGSize size = CGSizeMake(1.0f, 1.0f);
+    [value getValue:&size];
+    XCTAssertTrue(CGSizeEqualToSize(size, CGSizeZero));
+
+    value = nil;
+    value = kRZDBNilToCGRectZeroTransform(value);
+    CGRect rect = CGRectMake(1.0f, 1.0f, 1.0f, 1.0f);
+    [value getValue:&rect];
+    XCTAssertTrue(CGRectEqualToRect(rect, CGRectZero));
+
+    value = nil;
+    value = kRZDBNilToCGRectNullTransform(value);
+    rect = CGRectMake(1.0f, 1.0f, 1.0f, 1.0f);
+    [value getValue:&rect];
+    XCTAssertTrue(CGRectIsNull(rect));
+
+    value = @(NO);
+    value = kRZDBLogicalNegateTransform(value);
+    XCTAssertTrue([value boolValue]);
+
+    value = @(0.25);
+    value = kRZDBOneMinusTransform(value);
+    XCTAssertTrue([value doubleValue] == 0.75);
+
+    value = @(0x1337);
+    value = kRZDBBitwiseComplementTransform(value);
+    XCTAssertTrue([value longLongValue] == ~0x1337);
 }
 
 - (void)testDeallocation

--- a/Tests/RZDBTests/RZDBTests.m
+++ b/Tests/RZDBTests/RZDBTests.m
@@ -127,11 +127,13 @@
 
     for ( NSUInteger i = 0; i < 500000; i++ ) {
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            if ( arc4random() % 2 == 0 ) {
-                [testObj rz_addTarget:observer action:@selector(testCallback) forKeyPathChange:RZDB_KP_OBJ(testObj, string)];
-            }
-            else {
-                [testObj rz_removeTarget:observer action:@selector(testCallback) forKeyPathChange:RZDB_KP_OBJ(testObj, string)];
+            @autoreleasepool {
+                if ( arc4random() % 2 == 0 ) {
+                    [testObj rz_addTarget:observer action:@selector(testCallback) forKeyPathChange:RZDB_KP_OBJ(testObj, string)];
+                }
+                else {
+                    [testObj rz_removeTarget:observer action:@selector(testCallback) forKeyPathChange:RZDB_KP_OBJ(testObj, string)];
+                }
             }
         });
     }
@@ -215,8 +217,11 @@
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         [RZDBCoalesce begin];
         for ( NSUInteger i = 0; i < 5000; i++ ) {
-            RZDBTestObject *t = [testObjects objectAtIndex:arc4random() % testObjects.count];
-            t.string = @"New Value";
+            @autoreleasepool {
+                RZDBTestObject *t = [testObjects objectAtIndex:arc4random() % testObjects.count];
+                t.string = @"New Value";
+            }
+
         }
         [RZDBCoalesce commit];
 

--- a/Tests/RZDBTests/RZDBTests.m
+++ b/Tests/RZDBTests/RZDBTests.m
@@ -107,11 +107,16 @@
     RZDBTestObject *testObj = [RZDBTestObject new];
     RZDBTestObject *observer = [RZDBTestObject new];
     
-    [testObj rz_addTarget:observer action:@selector(changeCallback) forKeyPathChanges:@[RZDB_KP_OBJ(testObj, string), RZDB_KP_OBJ(testObj, callbackCalls)]];
+    [testObj rz_addTarget:observer action:@selector(changeCallback) forKeyPathChanges:@[RZDB_KP_OBJ(testObj, string), RZDB_KP_OBJ(testObj, callbackCalls)] callImmediately:YES];
     
     testObj.string = @"test";
     testObj.callbackCalls = 0;
     
+    XCTAssertTrue(observer.callbackCalls == 3, @"Callback called incorrect number of times. Expected:2 Actual:%i", (int)observer.callbackCalls);
+
+    observer.callbackCalls = 0;
+    [testObj rz_addTarget:observer action:@selector(changeCallbackWithDict:) forKeyPathChanges:@[RZDB_KP_OBJ(testObj, string), RZDB_KP_OBJ(testObj, callbackCalls)] callImmediately:YES];
+
     XCTAssertTrue(observer.callbackCalls == 2, @"Callback called incorrect number of times. Expected:2 Actual:%i", (int)observer.callbackCalls);
 }
 


### PR DESCRIPTION
- Added global header to import, `RZDataBinding.h`
- Renamed `RZDBKeyBindingFunction` -> `RZDBKeyBindingTransform`
- Added several convenience constants for common use case binding transforms
- Removed `RZDBObservableObject` and instead exposed `rz_cleanupObservers` if `RZDB_AUTOMATIC_CLEANUP` is disabled
- Binding and target/actions no longer use unneeded KVO options when registering observers
- Added `callImmediately` version of `rz_addTarget:action:forKeyPathChanges:`
- Improved tests and documentation